### PR TITLE
Fit in legts example is not good enough

### DIFF
--- a/source/examples/LETGpow/letgplaw.rst
+++ b/source/examples/LETGpow/letgplaw.rst
@@ -162,8 +162,8 @@ chi-square around 1::
 
 The reduced chi-squared value indicates that we found an acceptable fit and all
 parameter values are close to the original input values (the nH is so small in
-the input, that the fit may give a zero value as fit result). Note that your
-results may vary slightly, if you run this example, because |marx| is a
+the input that the fit may give a zero value as fit result). Note that your
+results may vary slightly if you run this example, because |marx| is a
 Monte-Carlo simulation based on random numbers.
 
 .. figure:: m1_fit.*

--- a/source/examples/LETGpow/letgplaw.rst
+++ b/source/examples/LETGpow/letgplaw.rst
@@ -73,7 +73,7 @@ the spectrum. The value of ``-1``
 as given above means that the integrated flux is to be taken from the file. 
 The results of the
 simulation will be written to a subdirectory called ``letgplaw``, as
-specified by the :par:`Output Dir` parameter.  After the simulation has
+specified by the :par:`OutputDir` parameter.  After the simulation has
 completed, a standard Chandra event file may be created using the :marxtool:`marx2fits`
 program:
 
@@ -154,14 +154,17 @@ following commands (positive order works similarly):
 This command sequence produced the following parameter values and a reduced
 chi-square around 1::
 
-    Reduced statistic     = 1.38457
-    Change in statistic   = 9.32606e+07
+    Reduced statistic     = 1.08292
+    Change in statistic   = 2.84957e+07
        a.nH           0
-       xp.PhoIndex    -1.77876
-       xp.norm        0.00114488
+       xp.PhoIndex    1.75727
+       xp.norm        0.10434
 
-Absorption and photons index are similar to what we put in the simulation, but
-the norm is way off. Maybe we should have used the RMF after all.
+The reduced chi-squared value indicates that we found an acceptable fit and all
+parameter values are close to the original input values (the nH is so small in
+the input, that the fit may give a zero value as fit result). Note that your
+results may vary slightly, if you run this example, because |marx| is a
+Monte-Carlo simulation based on random numbers.
 
 .. figure:: m1_fit.*
    :align: center

--- a/source/examples/LETGpow/spectralmodel.py
+++ b/source/examples/LETGpow/spectralmodel.py
@@ -19,7 +19,7 @@ a.nH = 0.001
 p.PhoIndex = 1.8
 p.norm = 0.1
 
-set_analysis("energy", factor=1)
+set_analysis("energy", factor=0)
 
 pl = get_source_plot()
 fluxdensity = pl.y


### PR DESCRIPTION
The fit typically gives a reduced chi^2 around 1.6 - that is much more than I had expected.

Either something in marx is wrong (then I should track that down) or something is not right in the was I make the arf in CIAO - then I should track that down and fix it.
