### PR TITLE
"SpectrumType" and "SourceType"

### DIFF
--- a/source/inbrief/simsetup.rst
+++ b/source/inbrief/simsetup.rst
@@ -333,8 +333,8 @@ If the values of :par:`SourceRA` and :par:`SourceDEC` are different
 from :par:`RA_Nom` and :par:`Dec_Nom`, the source will be off-axis.
 
 
-Source Spectrum and Spatial Distribution
-----------------------------------------
+Source Spectrum
+---------------
 This is described in more details in :ref:`sect-sourcemodels`. Here, we
 summarize the most important points.
 
@@ -343,6 +343,23 @@ of source photons: a built-in FLAT spectrum model
 which produces uniform flux over the specified energy range, or
 a FILE mode which reads the spectrum from an external ASCII file.
 The :par:`SpectrumType` parameter selects between these two options.
+In both cases, further parameters are needed to give details:
+
++-------------------+-------------------+-------------------------------+
+|:par:`SpectrumType`|Parameter          |Description                    |
++===================+===================+===============================+ 
+|FLAT               |:par:`MinEnergy`   |keV                            |
+|                   +-------------------+-------------------------------+
+|                   |:par:`MaxEnergy`   |keV                            |
+|                   +-------------------+-------------------------------+
+|                   |:par:`SourceFlux`  | phot/s/cm^2                   |
++-------------------+-------------------+-------------------------------+
+|FILE               |:par:`SpectrumFile`|phot/s/cm^2/keV - see text     |
+|                   +-------------------+-------------------------------+
+|                   |:par:`SourceFlux`  | < 0 to use data in the file   |
+|                   |                   |or > 0 to renormalize the file |
++-------------------+-------------------+-------------------------------+
+
 If the FLAT spectrum is selected, the :par:`SourceFlux` parameter
 is used to determine the overall normalization of the spectrum in
 photons/sec/cm^2.
@@ -374,6 +391,10 @@ will use the normalization inherent in the input spectrum.
 In this manner, several sources with a consistent spectral shape
 but varying total flux can be simulated using a single input spectrum
 file.
+
+The shape of the source on the sky
+----------------------------------
+Again, more details on this can be found in :ref:`sect-sourcemodels`.
 
 The spatial distribution of source photons in |marx| is determined
 by the choice of the :par:`SourceType` parameter.

--- a/source/inbrief/simsetup.rst
+++ b/source/inbrief/simsetup.rst
@@ -356,8 +356,9 @@ In both cases, further parameters are needed to give details:
 +-------------------+-------------------+-------------------------------+
 |FILE               |:par:`SpectrumFile`|phot/s/cm^2/keV - see text     |
 |                   +-------------------+-------------------------------+
-|                   |:par:`SourceFlux`  | < 0 to use data in the file   |
-|                   |                   |or > 0 to renormalize the file |
+|                   |:par:`SourceFlux`  |< 0 to use data in the file    |
+|                   |                   |or > 0 to renormalize the      |
+|                   |                   |spectrum in the file           |
 +-------------------+-------------------+-------------------------------+
 
 If the FLAT spectrum is selected, the :par:`SourceFlux` parameter


### PR DESCRIPTION
A user commented:

Hi Moritz, here are some of my thoughts on the MARX documentation.

I worked from this page: http://space.mit.edu/ASC/MARX/inbrief/simsetup.html

Looking at the section "Source Spectrum and Spatial Distribution" -- There is a lot of information here.  I think you could break these up into just "Source Spectrum" and "Source Spatial Distribution" or just plain "SpectrumType" and "SourceType" headers, since those are the relevant keywords.

The paragraph style also makes it difficult to keep track of the hierarchy of parameters.  I kind of like the format, for example, of Table 4.2 to help me keep track of such things.  It could look like this:

SpectrumType    & Parameter & Description \
FLAT   &  MinEnergy  & (keV) \
            &  MaxEnergy & (keV) \
            &  SourceFlux & (phot/s/cm^2) \

FILE    & SpectrumFile  &  (phot/s/cm^2/keV), include binning description in text \ 
            & SourceFlux     & < 0 to use data in SpectrumFile \
            &                        & > 0 to renormalize SpectrumFile \

Finally, I realize now that the major issue is that I didn't know which SourceFlux value MARX uses as default.  I assumed the default was to use the true values in SpectrumFile (and therefore SourceFlux = -1) because that made sense in my head.  Also, I imagine that having SourceFlux = -1 as default when SpectrumType=FLAT would force the user to define a SourceFlux and avoid any future mistakes.  So it was basically my assumptions that messed things up for me.
