### PR TITLE
Add use of negative NumRays for parameter description.

### DIFF
--- a/source/examples/LETGpow/letgplaw.rst
+++ b/source/examples/LETGpow/letgplaw.rst
@@ -1,3 +1,5 @@
+.. _sect-ex-letgplaw:
+
 Simulating an LETG/ACIS-S observation
 =====================================
 

--- a/source/inbrief/simsetup.rst
+++ b/source/inbrief/simsetup.rst
@@ -103,11 +103,12 @@ method most users will employ most of the time.
 
 .. parameter:: NumRays
 
-   This parameter sets the exact number of rays to run through the simulator
-   in *ray generation mode*. Note, that this value is *not* the
-   number of detected rays which will be produced (some rays maybe absorbed or
-   scattered outside of the detector). This parameter
-   specifies the number of input rays. 
+   This parameter sets the number of rays *denerated* 
+   in *ray generation mode*. Note, some rays maybe absorbed or
+   scattered outside of the detector, so the *detected* number of rays will in
+   general be lower than ``NumRays``. To specify the number of *detected* rays,
+   set ``NumRays`` to a negative number. An example for this case is given in
+   :ref:`_sect-ex-letgplaw`.
 
 .. parameter:: TStart
 

--- a/source/inbrief/simsetup.rst
+++ b/source/inbrief/simsetup.rst
@@ -103,8 +103,8 @@ method most users will employ most of the time.
 
 .. parameter:: NumRays
 
-   This parameter sets the number of rays *denerated* 
-   in *ray generation mode*. Note, some rays maybe absorbed or
+   This parameter sets the number of rays *generated* 
+   in *ray generation mode*. Note that some rays may be absorbed or
    scattered outside of the detector, so the *detected* number of rays will in
    general be lower than ``NumRays``. To specify the number of *detected* rays,
    set ``NumRays`` to a negative number. An example for this case is given in

--- a/source/inbrief/simsetup.rst
+++ b/source/inbrief/simsetup.rst
@@ -108,7 +108,7 @@ method most users will employ most of the time.
    scattered outside of the detector, so the *detected* number of rays will in
    general be lower than ``NumRays``. To specify the number of *detected* rays,
    set ``NumRays`` to a negative number. An example for this case is given in
-   :ref:`_sect-ex-letgplaw`.
+   :ref:`sect-ex-letgplaw`.
 
 .. parameter:: TStart
 


### PR DESCRIPTION
This was explained in an example, but not in the description of the `NumRays` parameter, where you would expect it.
A user asked me for this feature, and when I tried to send him a link to the appropriate documentation, I noticed that it was not documented where it would have been. 
This PR will fix that oversight.
