### PR TITLE
Including background in marx simulation: Wrong background rate used

### DIFF
--- a/source/examples/background/background.rst
+++ b/source/examples/background/background.rst
@@ -149,9 +149,9 @@ a single event file. This involves the following steps:
     - Estimate the number of background photons we want to simulate.
       Looking at `the appropriate table in the Observatory Guide 
       <http://cxc.harvard.edu/proposer/POG/html/chap6.html#tth_sEc6.16.2>`_
-      we see that roughly 3 cts/s (in the event grades we care for) is a good,
-      conservative estiamte. For an observation of 50 ks, we thus decide to
-      select roughly 150,000 photons.
+      we see that roughly 0.3 cts/s (in the event grades we care for) is a good,
+      conservative estiamte. For an observation of 100 ks, we thus decide to
+      select roughly 30,000 photons.
     - Events in the "blank sky" files are sorted in x and y. In order to
       select a random subset, we use :ciao:`dmtcalc` to assign a random number
       in column ``randnum`` and multiply it with the ratio of the number of
@@ -159,7 +159,7 @@ a single event file. This involves the following steps:
       want to select.
     - We copy only those photons where the ratio is smaller than 1. Since this
       involves a random number, this also introduces a "random error" to the
-      number of photons we select - it will not be exactly 150,000. 
+      number of photons we select - it will not be exactly 30,000. 
  
 #. Add a time column to the "blank sky" file and fill it with random values
    during the observation.
@@ -244,7 +244,7 @@ of the input spectrum format for |marx|):
    Extracted "blank-sky" spectrum.
 
 
-Again, we want a source flux of about 3 counts/s over the entire detector. 
+Again, we want a source flux of about 0.3 counts/s over the entire detector. 
 :par:`SourceFlux` expects the flux in counts/s/cm^2, so we would have to devide
 by *Chandra*'s effective area. Alternatively, we can just set the
 exact number of photons we want to detect with :par:`ExposureTime=0` and :par:`NumRays`
@@ -264,7 +264,7 @@ lower background level in the input "blank sky" file.
 
    Binned "blank sky" file for chip 7
 
-To reproduce this patters, we use |marx| with :par:`SourceType="IMAGE"`. 
+To reproduce this pattern, we use |marx| with :par:`SourceType="IMAGE"`. 
 There is a trade-off here: If we bin the image too much, we smooth out the
 structure, if we bin too little such that we still see the random noise in the
 image, then our |marx| simulation will produce an event distribution that shows

--- a/source/examples/background/extract_blanksky.sh
+++ b/source/examples/background/extract_blanksky.sh
@@ -1,9 +1,9 @@
-dmextract infile="acis7s_bkg_reproj.fits[sky=rotbox(1:59:59,+39:59:20,3.2',3.5',0)][bin pi]" outfile='blank_sky.pi' wmap="[bin tdet=8]"
+dmextract infile="acis7s_bkg_reproj.fits[sky=rotbox(1:59:59,+39:59:20,3.2',3.5',0)][bin pi]" outfile='blank_sky.pi' wmap="[bin tdet=8]" clobber=yes
 
-asphist infile=diffuse_asol1.fits outfile=blank_sky.asphist evtfile="diffuse_evt2.fits[ccd_id=7]"
+asphist infile=diffuse_asol1.fits outfile=blank_sky.asphist evtfile="diffuse_evt2.fits[ccd_id=7]" clobber=yes
 
-sky2tdet infile="acis7s_bkg_reproj.fits[sky=rotbox(1:59:59,+39:59:20,3.2',3.5',0)][bin sky=8]" asphistfile="blank_sky.asphist" outfile="blank_sky_tdet.fits[wmap]"
+sky2tdet infile="acis7s_bkg_reproj.fits[sky=rotbox(1:59:59,+39:59:20,3.2',3.5',0)][bin sky=8]" asphistfile="blank_sky.asphist" outfile="blank_sky_tdet.fits[wmap]" clobber=yes
 
-mkwarf infile="blank_sky_tdet.fits[wmap]" outfile=blank_sky.arf weightfile=blank_sky.wfef egridspec=0.3:11.0:0.1  mskfile=NONE spectrumfile=NONE pbkfile=NONE
+mkwarf infile="blank_sky_tdet.fits[wmap]" outfile=blank_sky.arf weightfile=blank_sky.wfef egridspec=0.3:11.0:0.1  mskfile=NONE spectrumfile=NONE pbkfile=NONE clobber=yes
 
-mkrmf infile=CALDB outfile=blank_sky.rmf axis1="energy=0:1" axis2="pi=1:1024:1" weights=blank_sky.wfef
+mkrmf infile=CALDB outfile=blank_sky.rmf axis1="energy=0:1" axis2="pi=1:1024:1" weights=blank_sky.wfef clobber=yes

--- a/source/examples/background/marx4bkg.sh
+++ b/source/examples/background/marx4bkg.sh
@@ -1,5 +1,5 @@
 marx SourceFlux=3. SpectrumType="FILE" SpectrumFile="bkgspec.tbl" \
-       ExposureTime=0 NumRays=-150000 TStart=2012.5 OutputDir=bkg \
+       ExposureTime=0 NumRays=-30000 TStart=2012.5 OutputDir=bkg \
        DetectorType="ACIS-S" DitherModel="INTERNAL" RA_Nom=30 Dec_Nom=40 \
        Roll_Nom=0 SourceRA=30 SourceDEC=40 \
        SourceType="IMAGE" S-ImageFile="chip-shape.fits"

--- a/source/examples/background/mergebkg.sh
+++ b/source/examples/background/mergebkg.sh
@@ -3,21 +3,21 @@
 # Pick how many background photons we want to add to our simulation.
 
 n=`dmlist acis7sbkg.fits header,raw | grep NAXIS2 | awk '{ print $6 }'`
-dmtcalc acis7sbkg.fits temp.fits expression="randnum=$n/1.55e5*#trand"
-dmcopy "temp.fits[randnum=0:1]" temp2.fits
+dmtcalc acis7sbkg.fits temp.fits expression="randnum=$n/3e4*#trand" clobber=yes
+dmcopy "temp.fits[randnum=0:1]" temp2.fits clobber=yes
 
 # Assign some random time during the observation to each photons.
 t0=`dmkeypar diffuse_evt2.fits TSTART echo+`
 t1=`dmkeypar diffuse_evt2.fits TSTOP echo+`
 
-dmtcalc temp2.fits temp3.fits expression="time=$t0+($t1-$t0)*#trand"
-dmsort temp3.fits temp4.fits keys=TIME
+dmtcalc temp2.fits temp3.fits expression="time=$t0+($t1-$t0)*#trand" clobber=yes
+dmsort temp3.fits temp4.fits keys=TIME clobber=yes
 
 # Reproject the blank sky fields to the same position on the sky as the marx simulation.
 punlearn reproject_events 
-reproject_events infile=temp4.fits outfile=acis7s_bkg_reproj.fits aspect=diffuse_asol1.fits match=diffuse_evt2.fits
+reproject_events infile=temp4.fits outfile=acis7s_bkg_reproj.fits aspect=diffuse_asol1.fits match=diffuse_evt2.fits clobber=yes
 
 # Merge marx simulation and blank sky fields into a single fits table.
 punlearn dmmerge
-dmmerge "diffuse_evt2.fits[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]","acis7s_bkg_reproj.fits[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]" merged.fits
+dmmerge "diffuse_evt2.fits[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]","acis7s_bkg_reproj.fits[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]" merged.fits clobber=yes
 

--- a/source/examples/background/runmarx.inc
+++ b/source/examples/background/runmarx.inc
@@ -1,5 +1,5 @@
- marx SourceFlux=0.06 SpectrumType="FILE" SpectrumFile="source_flux.tbl" \
-       ExposureTime=50000 TStart=2012.5 OutputDir=diffuse \
+ marx SourceFlux=0.02 SpectrumType="FILE" SpectrumFile="source_flux.tbl" \
+       ExposureTime=100000 TStart=2012.5 OutputDir=diffuse \
        DetectorType="ACIS-S" DitherModel="INTERNAL" RA_Nom=30 Dec_Nom=40 \
        Roll_Nom=0 SourceRA=30 SourceDEC=40 \
        SourceType="GAUSS" S-GaussSigma=60


### PR DESCRIPTION
Hi Moritz.

I was just looking at the "Including background in marx simulation" page,
specifically the blanksky background section

http://space.mit.edu/ASC/MARX/examples/background/background.html#adding-blank-sky-background-to-a-marx-simulation

and in the list of steps, for the number of background photons to
simulate, it's stated that roughly 3 cts/s for S3 is needed based on the
linked table in the POG.  Is this right? Looking at table 6.8, it
looks like for 0.5-7.0 keV, the rate is 0.3 cts/s, unless I'm looking at the wrong table.

Thanks,
~Nick
